### PR TITLE
refactor: add ability to specify input JSON file as an arg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ obj/
 riderModule.iml
 /_ReSharper.Caches/
 .idea
+.vscode

--- a/FFPipeline/FFPipeline.csproj
+++ b/FFPipeline/FFPipeline.csproj
@@ -1,33 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <PublishAot>true</PublishAot>
-        <InvariantGlobalization>true</InvariantGlobalization>
-        <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
-        <LangVersion>13</LangVersion>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+    <LangVersion>13</LangVersion>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="CliWrap" Version="3.6.7" />
-      <PackageReference Include="ConsoleAppFramework" Version="5.2.4">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
-      <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-      <PackageReference Include="System.Text.Json" Version="9.0.0" />
-      <PackageReference Include="ZLogger" Version="2.5.7" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CliWrap" Version="3.6.7" />
+    <PackageReference Include="ConsoleAppFramework" Version="5.2.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
+    <PackageReference Include="ZLogger" Version="2.5.7" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="FFmpeg\" />
-    </ItemGroup>
+  <ItemGroup>
+    <Folder Include="FFmpeg\" />
+  </ItemGroup>
 
 </Project>

--- a/FFPipeline/JsonValueParserAttribute.cs
+++ b/FFPipeline/JsonValueParserAttribute.cs
@@ -1,0 +1,26 @@
+using ConsoleAppFramework;
+
+namespace FFPipeline;
+
+[AttributeUsage(AttributeTargets.Parameter)]
+public class JsonValueParserAttribute<T> : Attribute, IArgumentParser<T>
+{
+    public static bool TryParse(ReadOnlySpan<char> input, out T result)
+    {
+        var inputFileString = input.ToString();
+        if (!File.Exists(inputFileString))
+        {
+            result = default;
+            return false;
+        }
+
+        var o = JsonExtensions.Deserialize<T>(File.ReadAllText(inputFileString), SourceGenerationContext.Default);
+        if (o == null)
+        {
+            result = default;
+            return false;
+        }
+        result = o;
+        return true;
+    }
+}


### PR DESCRIPTION
Includes a custom argument parser for taking a JSON file path as input and parsing the specified type. We probably won't want this forever, just because of its simplicity and the assumptions it makes, but it makes it simple for a fast start.